### PR TITLE
Use portpicker in host integration tests

### DIFF
--- a/emb/network/transport/host/zmq.cc
+++ b/emb/network/transport/host/zmq.cc
@@ -14,7 +14,6 @@ struct Zmq::ZmqImpl {
     ZmqImpl() {}
 
     void initialize() {
-
         // Create a ZMQ context
         context = zmq::context_t(1);
 
@@ -23,9 +22,13 @@ struct Zmq::ZmqImpl {
             socket = zmq::socket_t(context, zmq::socket_type::dealer);
             // Bind the socket to an inproc address
             socket.bind("ipc://unittest");
+        } else if (std::getenv("ZMQ_PORT")) {
+            socket = zmq::socket_t(context, zmq::socket_type::dealer);
+            // Bind the socket to the specified port
+            socket.bind(std::string("tcp://*:") + std::getenv("ZMQ_PORT"));
         } else {
             socket = zmq::socket_t(context, zmq::socket_type::dealer);
-            // Bind the socket to a TCP port
+            // Bind the socket to a default port
             socket.bind("tcp://*:1337");
         }
     }

--- a/emb/project/host_test_base.py
+++ b/emb/project/host_test_base.py
@@ -20,11 +20,7 @@ class HostTestBase[C: client.ClientLike, N: bh.BhNode](unittest.TestCase):
     def setUp(self) -> None:
         host_bin = pathlib.Path(os.environ['HOST_BIN'])
 
-        # NOTE: This `DEFAULT_ADDRESS` use is naughty and prevents concurrent tests
-        # from running. A port picker would be better, but right now there's no method
-        # to pass the port to the host binary (need to abstract `main` for host compilation).
         port = portpicker.pick_unused_port()
-        # TODO: Use `address` instead of `DEFAULT_ADDRESS`
         address = tcp.Zmq.DEFAULT_HOST + f':{port}'
 
         self.host = subprocess.Popen(

--- a/emb/project/host_test_base.py
+++ b/emb/project/host_test_base.py
@@ -20,15 +20,6 @@ class HostTestBase[C: client.ClientLike, N: bh.BhNode](unittest.TestCase):
     def setUp(self) -> None:
         host_bin = pathlib.Path(os.environ['HOST_BIN'])
 
-        self.host = subprocess.Popen(
-            [str(host_bin)],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-        self.addCleanup(self.host.terminate)
-
         # NOTE: This `DEFAULT_ADDRESS` use is naughty and prevents concurrent tests
         # from running. A port picker would be better, but right now there's no method
         # to pass the port to the host binary (need to abstract `main` for host compilation).
@@ -36,7 +27,17 @@ class HostTestBase[C: client.ClientLike, N: bh.BhNode](unittest.TestCase):
         # TODO: Use `address` instead of `DEFAULT_ADDRESS`
         address = tcp.Zmq.DEFAULT_HOST + f':{port}'
 
-        transporter = tcp.Zmq(tcp.Zmq.DEFAULT_ADDRESS)
+        self.host = subprocess.Popen(
+            [str(host_bin)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={'ZMQ_PORT': str(port)},
+        )
+
+        self.addCleanup(self.host.terminate)
+
+        transporter = tcp.Zmq(address)
         self.node = self.NODE_CLS(
             comms_transporter=transporter, log_transporter=transporter
         )


### PR DESCRIPTION
Small thing that bothered me; two hosts tests running together would conflict. Let's just use envvars to pass around the deconflicted ports
