### PR TITLE
Double Pico flash performance

### DIFF
--- a/emb/project/base/client.py
+++ b/emb/project/base/client.py
@@ -134,9 +134,7 @@ class BaseClient(client.Client):
 
     def reset(self) -> None:
         # Manually transmit the reset message to avoid waiting for a response
-        self._node._comms_transporter.send(
-            self._node._serializer.serialize(base_bh.Ping(0), base_bh.RESET.request_id)
-        )
+        self._node.command(base_bh.Ping(0), base_bh.RESET.request_id)
 
     def revert_flash(self) -> None:
         # The previous image is stored in the other bank, so we can just tell

--- a/emb/util/BUILD
+++ b/emb/util/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bzl/macros:cc.bzl", "cc_unittest")
 
 cc_library(
     name = "log",
@@ -7,4 +8,16 @@ cc_library(
     deps = [
         "//emb/project/base:base_bh_cc",
     ],
+)
+
+cc_library(
+    name = "ring_buffer",
+    hdrs = ["ring_buffer.hpp"],
+    visibility = ["//visibility:public"],
+)
+
+cc_unittest(
+    name = "ring_buffer_test",
+    srcs = ["ring_buffer_test.cc"],
+    deps = [":ring_buffer"],
 )

--- a/emb/util/ring_buffer.hpp
+++ b/emb/util/ring_buffer.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <array>
+#include <cinttypes>
+#include <initializer_list>
+
+namespace emb {
+namespace util {
+
+// Fixed-size ring buffer
+template <typename T, uint8_t Size> class RingBuffer {
+  public:
+    RingBuffer() : head_(0), tail_(0), full_(false) {}
+
+    RingBuffer(std::initializer_list<T> init_list)
+        : head_(0), tail_(0), full_(false) {
+        for (const auto &item : init_list) {
+            push(item);
+        }
+    }
+
+    bool contains(const T &item) {
+        for (uint8_t i = tail_; i < tail_ + size(); ++i) {
+            if (buffer_[i % Size] == item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void push(const T &item) {
+        buffer_[head_] = item;
+        if (full_) {
+            tail_ = (tail_ + 1) % Size;
+        }
+        head_ = (head_ + 1) % Size;
+        full_ = head_ == tail_;
+    }
+
+    T pop() {
+        // NOTE: Not checking if `empty` due to no exceptions
+        auto item = buffer_[tail_];
+        full_ = false;
+        tail_ = (tail_ + 1) % Size;
+        return item;
+    }
+
+    bool empty() const { return (!full_ && (head_ == tail_)); }
+
+    bool full() const { return full_; }
+
+    uint8_t size() const {
+        uint8_t size = Size;
+        if (!full_) {
+            if (head_ >= tail_) {
+                size = head_ - tail_;
+            } else {
+                size = Size + head_ - tail_;
+            }
+        }
+        return size;
+    }
+
+  private:
+    std::array<T, Size> buffer_;
+    uint8_t head_;
+    uint8_t tail_;
+    bool full_;
+};
+
+}  // namespace util
+}  // namespace emb

--- a/emb/util/ring_buffer_test.cc
+++ b/emb/util/ring_buffer_test.cc
@@ -1,0 +1,72 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "emb/util/ring_buffer.hpp"
+
+using namespace testing;
+
+namespace emb {
+namespace util {
+
+class RingBufferTest : public Test {
+  protected:
+    RingBuffer<int, 5> buffer;
+    RingBuffer<int, 5> initialized_buffer{1, 2, 3, 4, 5};
+};
+
+TEST_F(RingBufferTest, IsEmptyInitially) {
+    EXPECT_TRUE(buffer.empty());
+    EXPECT_FALSE(buffer.full());
+    EXPECT_FALSE(buffer.contains(0));
+}
+
+TEST_F(RingBufferTest, AddElement) {
+    buffer.push(1);
+    EXPECT_FALSE(buffer.empty());
+    EXPECT_FALSE(buffer.full());
+    EXPECT_EQ(buffer.size(), 1);
+    EXPECT_TRUE(buffer.contains(1));
+}
+
+TEST_F(RingBufferTest, PopElement) {
+    buffer.push(1);
+    int value = buffer.pop();
+    EXPECT_EQ(value, 1);
+    EXPECT_TRUE(buffer.empty());
+    EXPECT_FALSE(buffer.full());
+    EXPECT_FALSE(buffer.contains(1));
+}
+
+TEST_F(RingBufferTest, FillBuffer) {
+    for (int i = 0; i < 5; ++i) {
+        buffer.push(i);
+    }
+    EXPECT_TRUE(buffer.full());
+    EXPECT_FALSE(buffer.empty());
+    EXPECT_EQ(buffer.size(), 5);
+    EXPECT_TRUE(buffer.contains(0));
+}
+
+TEST_F(RingBufferTest, OverflowBuffer) {
+    for (int i = 0; i < 5; ++i) {
+        buffer.push(i);
+    }
+    buffer.push(5);
+    EXPECT_TRUE(buffer.full());
+    EXPECT_EQ(buffer.size(), 5);
+    EXPECT_EQ(buffer.pop(), 1);  // Oldest element should be removed
+    EXPECT_FALSE(buffer.contains(1));
+    EXPECT_TRUE(buffer.contains(5));
+}
+
+TEST_F(RingBufferTest, InitializedBuffer) {
+    EXPECT_FALSE(initialized_buffer.empty());
+    EXPECT_TRUE(initialized_buffer.full());
+    EXPECT_EQ(initialized_buffer.size(), 5);
+    EXPECT_EQ(initialized_buffer.pop(), 1);
+    EXPECT_EQ(initialized_buffer.size(), 4);
+    EXPECT_TRUE(initialized_buffer.contains(2));
+}
+
+}  // namespace util
+}  // namespace emb

--- a/emb/yaal/BUILD
+++ b/emb/yaal/BUILD
@@ -16,6 +16,7 @@ cc_library(
     deps = select(
         {
             "@platforms//cpu:armv6-m": [
+                "//emb/util:ring_buffer",
                 "@pico-sdk//src/rp2_common/hardware_flash",
             ],
             "//conditions:default": [

--- a/emb/yaal/flash.hpp
+++ b/emb/yaal/flash.hpp
@@ -15,7 +15,12 @@ const uint8_t *get_flash_ptr(uint32_t addr);
 // Get the address of a flash sector
 uint32_t get_flash_sector_addr(uint8_t sector);
 
-// Write data to flash memory
+// Write data to flash memory. Writes MUST be aligned to 256-byte pages;
+// i.e. `addr` and `data.size()` must be multiples of 256.
+//
+// This method is optimized for "minimal work"; i.e. it will only erase the
+// sector if it hasn't been written to before. This makes reads on the same
+// sector, but different address, after a write invalid.
 void flash_write(uint32_t addr, std::span<const uint8_t> data);
 
 // Write a sector of data to flash memory.


### PR DESCRIPTION
Double the Pico flash performance by placing more restrictions on its usage. Keeping things aligned and with "proper usage" lets us do a minimal amount of work with erasing and writing.

This brought BLE OTA update times down to ~6 min, with some performance improvements in the bootloader as well.
