### PR TITLE
add a self hosted runner

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build-and-test:
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+# Do the Bazel thing
+name: Test All
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: self-hosted
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    #   - uses: bazelbuild/setup-bazelisk@v3
+      - name: Build
+        run: |
+          bazel build //...
+      - name: Test
+        run: |
+          bazel test //...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,12 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-and-test:
     runs-on: self-hosted
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-    #   - uses: bazelbuild/setup-bazelisk@v3
       - name: Build
         run: |
           bazel build //...


### PR DESCRIPTION
Add a Pi 5 (maple) as a self hosted runner, with a simple build & test workflow on PRs. Appropriate security hardening should be in place.
