### PR TITLE
Wizaidry arg fix

### DIFF
--- a/nlb/BUILD
+++ b/nlb/BUILD
@@ -38,7 +38,7 @@ py_package(
 )
 
 # bazel run --config pypi_test --embed_label=0.0.7 -- //nlb:nlb_wheel.publish --repository testpypi
-# bazel run --config pypi --embed_label=0.2.0 -- //nlb:nlb_wheel.publish --repository pypi
+# bazel run --config pypi --embed_label=0.2.1 -- //nlb:nlb_wheel.publish --repository pypi
 py_wheel(
     name = "nlb_wheel",
     data_files = {},  # TODO: Add completion data for click entrypoints

--- a/nlb/pypi_README.md
+++ b/nlb/pypi_README.md
@@ -15,3 +15,5 @@ nlb<br />
 ├── tailscale -> Tailscale utilities<br />
 ├── util -> Utilities<br />
 └── wizaidry -> Library for creating proto-Agentic AI wizards<br />
+
+`wizaidry` has its own [blog post](https://ryandraves.github.io/nlb/posts/wizaidry), which can serve as a Getting Started page.

--- a/nlb/wizaidry/util.py
+++ b/nlb/wizaidry/util.py
@@ -43,10 +43,7 @@ def get_assistant_tool_schema(
     signature = introspection.parse_signature_and_docs(func)
 
     properties = {
-        arg: {
-            'description': signature.arg_descriptions[arg],
-            'title': arg.title().replace('_', ' '),  # Convert snake_case to Title Case
-        }
+        arg: {'description': signature.arg_descriptions[arg], 'title': arg}
         | _get_arg_type(signature.arg_types[arg])
         for arg in signature.arg_descriptions
     }
@@ -84,10 +81,7 @@ def get_realtime_tool_schema(
     signature = introspection.parse_signature_and_docs(func)
 
     properties = {
-        arg: {
-            'description': signature.arg_descriptions[arg],
-            'title': arg.title().replace('_', ' '),  # Convert snake_case to Title Case
-        }
+        arg: {'description': signature.arg_descriptions[arg], 'title': arg}
         | _get_arg_type(signature.arg_types[arg])
         for arg in signature.arg_descriptions
     }


### PR DESCRIPTION
Add a small fix to #111 to not convert argument names to title case. While that does match the JSON Schema behavior (at least as `pydantic` defines it), it was confusing the models as they'd semi-randomly pick between the original and the title-cased name. A few test runs of only using the correct names yielded more consistent results.
