### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/python_publish.yaml
+++ b/.github/workflows/python_publish.yaml
@@ -30,4 +30,4 @@ jobs:
           echo "${{ secrets.PYPI_TOKEN }}" > services/secrets/pypi.token
 
       - name: Publish to PyPI
-        run: ./tools/release/python/publish.sh
+        run: ./tools/release/python/publish.sh pypi

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -15,7 +15,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,11 +27,6 @@ jobs:
         run: |
           sudo apt-get install -y portaudio19-dev
           echo "build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }}" > .user.bazelrc
-
-      - name: Set up Git user
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
       - name: Prepare Python release
         run: |
@@ -41,6 +39,7 @@ jobs:
           branch: 'release/python-bump-${{ github.event.inputs.bump_type }}'
           title: 'Python Release: ${{ github.event.inputs.bump_type }} bump'
           sign-commits: true
+          draft: true
           body: |
             Automated PR for a ${{ github.event.inputs.bump_type }} to the Python package version.
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,11 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fix the Python release workflows. Reading through https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs, I'm thinking "select ready-for-review to trigger workflows" is the least hassle here.
