### PR TITLE
Sharetrace: A tool to share Python tracebacks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
         "github.copilot",
         "github.copilot-chat",
         "github.vscode-github-actions",
+        "gruntfuggly.triggertaskonsave",
         "jeff-hykin.better-cpp-syntax",
         "ms-python.python",
         "ms-python.vscode-pylance",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -126,4 +126,9 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 2,
     },
+    "triggerTaskOnSave.tasks": {
+        "Update requirements.txt": [
+            "requirements.txt"
+        ]
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "Update requirements.txt",
             "type": "shell",
-            "command": "bazel run //:requirements.update && bazel run //:venv venv",
+            "command": "bazel run //:requirements.update && bazel run //:venv venv && venv/bin/pip install -e ${workspaceFolder}",
             "problemMatcher": []
         }
     ]

--- a/BUILD
+++ b/BUILD
@@ -10,6 +10,8 @@ package(default_visibility = ["//:__subpackages__"])
 # Create the root of the "virtual store" of npm dependencies under bazel-out
 npm_link_all_packages(name = "node_modules")
 
+exports_files(["requirements_legacy.txt"])
+
 buildifier(
     name = "buildifier.check",
     diff_command = "diff -u",

--- a/nlb/BUILD
+++ b/nlb/BUILD
@@ -27,6 +27,10 @@ py_package(
         "//nlb/mcp:file_edit_mcp",
         "//nlb/mcp:tool_manager",
         "//nlb/mcp:util",
+        "//nlb/sharetrace",
+        "//nlb/sharetrace:interface",
+        "//nlb/sharetrace:sharetrace_demo",
+        "//nlb/sharetrace:st",
         "//nlb/tailscale:nlb_tailscale",
         "//nlb/util:click_utils",
         "//nlb/util:console_utils",
@@ -46,6 +50,21 @@ py_package(
     ],
 )
 
+py_package(
+    # This is a streamlined version of the main nlb package that supports Python 3.10
+    name = "some_python_modules",
+    packages = [
+        "nlb",
+    ],
+    deps = [
+        "//nlb/sharetrace",
+        "//nlb/sharetrace:interface",
+        "//nlb/sharetrace:sharetrace_demo",
+        "//nlb/sharetrace:st",
+        "//nlb/util:console_utils",
+    ],
+)
+
 py_wheel(
     name = "nlb_wheel",
     # Update via `tools/release/python/update_build.sh`
@@ -58,6 +77,8 @@ py_wheel(
         "//nlb/authentik:nlb_invite_completions": "data/share/completions/nlb_invite-completion.bash",
         "//nlb/mcp:arduino_mcp_completions": "data/share/completions/arduino_mcp-completion.bash",
         "//nlb/mcp:file_edit_mcp_completions": "data/share/completions/file_edit_mcp-completion.bash",
+        "//nlb/sharetrace:sharetrace_completions": "data/share/completions/sharetrace-completion.bash",
+        "//nlb/sharetrace:sharetrace_demo_completions": "data/share/completions/sharetrace_demo-completion.bash",
     },
     description_file = "pypi_README.md",
     distribution = "nl_blocks",  # Unfortunate PyPI name collision
@@ -70,6 +91,8 @@ py_wheel(
         "nlb_gh_feature = nlb.github.nlb_gh_feature:main",
         "nlb_invite = nlb.authentik.nlb_invite:main",
         "nlb_tailscale = nlb.tailscale.nlb_tailscale:main",
+        "sharetrace = nlb.sharetrace.sharetrace:main",
+        "sharetrace_demo = nlb.sharetrace.sharetrace_demo:main",
         "venv_completions = nlb.util.venv_completions:main",
     ]},
     license = "MIT",
@@ -78,7 +101,7 @@ py_wheel(
         "Repository": "https://github.com/RyanDraves/nlb",
         "Issues": "https://github.com/RyanDraves/nlb/issues",
     },
-    python_requires = ">=3.12",  # Uses new type var syntax
+    python_requires = ">=3.10",  # Uses new type var syntax
     python_tag = "py3",
     # Looser requirements than the lockfile
     requires_file = "//:requirements.txt",
@@ -88,5 +111,41 @@ py_wheel(
     version = "{BUILD_EMBED_LABEL}",
     deps = [
         ":all_python_modules",
+    ],
+)
+
+# repository="testpypi"  # Use "testpypi" for testing, "pypi" for production
+# version=$(cat tools/release/python/VERSION.txt)
+# bazel run --config quiet --config stamp --config "$repository" --embed_label="$version" //nlb:nlb_wheel_legacy.publish -- --repository "$repository"
+py_wheel(
+    name = "nlb_wheel_legacy",
+    data_files = {
+        "//nlb/util:venv_completions_completions": "data/share/completions/venv_completions-completion.bash",
+        "//nlb/sharetrace:sharetrace_completions": "data/share/completions/sharetrace-completion.bash",
+        "//nlb/sharetrace:sharetrace_demo_completions": "data/share/completions/sharetrace_demo-completion.bash",
+    },
+    description_file = "pypi_README_legacy.md",
+    distribution = "nlb_legacy",
+    entry_points = {"console_scripts": [
+        "sharetrace = nlb.sharetrace.sharetrace:main",
+        "sharetrace_demo = nlb.sharetrace.sharetrace_demo:main",
+        "venv_completions = nlb.util.venv_completions:main",
+    ]},
+    license = "MIT",
+    # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
+    project_urls = {
+        "Repository": "https://github.com/RyanDraves/nlb",
+        "Issues": "https://github.com/RyanDraves/nlb/issues",
+    },
+    python_requires = ">=3.10",  # Looser version requirements
+    python_tag = "py3",
+    # Looser requirements than a lockfile
+    requires_file = "//:requirements_legacy.txt",
+    stamp = -1,  # Let the `--[no]stamp` flag control stamping
+    summary = "Ryan's fever dreams",
+    twine = "@publish_deps//twine",
+    version = "{BUILD_EMBED_LABEL}",
+    deps = [
+        ":some_python_modules",
     ],
 )

--- a/nlb/pypi_README.md
+++ b/nlb/pypi_README.md
@@ -8,11 +8,13 @@ Docs? No thanks. Here's a simple directory tree until ReadTheDocs is setup:
 
 nlb<br />
 ├── arduino -> Client wrappers for the Arduino CLI<br />
+├── authentik -> CLI to add friends to an Authentik deployment<br />
 ├── buffham -> Serialization & RPC library<br />
 ├── datastructure -> Datastructure implementations<br />
 ├── github -> Github utilities<br />
 ├── hyd -> Fancy progress bars<br />
 ├── models -> Toy problems for algorithmic development (mostly `.gitignore`'d)<br />
+├── sharetrace -> Library & CLI to share Python tracebacks<br />
 ├── tailscale -> Tailscale utilities<br />
 ├── util -> Utilities<br />
 └── wizaidry -> Library for creating proto-Agentic AI wizards<br />

--- a/nlb/pypi_README_legacy.md
+++ b/nlb/pypi_README_legacy.md
@@ -1,0 +1,7 @@
+This is a streamlined version of the main [nlb package](https://pypi.org/project/nl-blocks/) that supports Python 3.10. This package is published as `nlb-legacy` on PyPI, however it is imported as its canonical `nlb` name.
+
+Docs? No thanks. Here's a simple directory tree until ReadTheDocs is setup:
+
+nlb<br />
+├── sharetrace -> Library & CLI to share Python tracebacks<br />
+└── util -> Utilities<br />

--- a/nlb/sharetrace/BUILD
+++ b/nlb/sharetrace/BUILD
@@ -1,0 +1,45 @@
+load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@pip//:requirements.bzl", "requirement")
+load("//bzl/macros:python.bzl", "py_binary")
+
+py_library(
+    name = "interface",
+    srcs = ["interface.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("marshmallow_dataclass"),
+    ],
+)
+
+py_library(
+    name = "st",
+    srcs = ["st.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":interface",
+    ],
+)
+
+py_binary(
+    name = "sharetrace_demo",
+    srcs = ["sharetrace_demo.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("rich-click"),
+        ":st",
+    ],
+)
+
+py_binary(
+    name = "sharetrace",
+    srcs = ["sharetrace.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("inquirerpy"),
+        requirement("jinja2"),
+        requirement("pygments"),
+        requirement("rich-click"),
+        ":interface",
+        "//nlb/util:console_utils",
+    ],
+)

--- a/nlb/sharetrace/README.md
+++ b/nlb/sharetrace/README.md
@@ -1,0 +1,45 @@
+# Sharetrace
+A Python library & CLI for capturing and sharing comprehensive traceback information.
+
+## Overview
+
+Sharetrace makes it easier to share Python exceptions and tracebacks with others by capturing:
+
+- Full exception details (type, message, traceback)
+- Code context around each frame in the stack trace
+- Git repository information (if available)
+- System information (Python version, platform, etc.)
+- Local variable values at each frame
+
+All this information is saved to a cache directory as JSON files that can later be used to generate shareable HTML reports.
+
+## Usage
+
+### Capture Traceback Information
+
+```python
+from nlb.sharetrace import st
+
+# Install the exception hook (call this early in your program)
+sharetrace.install_exception_hook()
+
+# Now any unhandled exceptions will be captured automatically
+raise ValueError("This will be captured!")
+```
+
+### Generate Shareable HTML Pages
+
+Just invoke the interactive CLI!
+
+```bash
+sharetrace [--open-browser]
+```
+
+## Examples
+
+A demo traceback can be created with `sharetrace_demo` and visualized with `sharetrace`.
+
+## Notes
+
+- `KeyboardInterrupt` and `SystemExit` are not captured (they use the default handler)
+- If the capture process fails, the original exception is still displayed

--- a/nlb/sharetrace/interface.py
+++ b/nlb/sharetrace/interface.py
@@ -1,0 +1,106 @@
+import dataclasses
+import datetime
+import pathlib
+from typing import Any, cast
+
+import marshmallow_dataclass
+
+TRACE_CACHE_DIR = pathlib.Path.home() / '.cache' / 'sharetrace'
+# Browsers don't like file:// URLs with `.` in the path (apparently?)
+TRACE_OUTPUT_DIR = pathlib.Path.home() / 'sharetrace'
+
+
+@dataclasses.dataclass
+class GitInfo:
+    repository: str | None
+    commit: str | None
+    branch: str | None
+    root: str | None
+
+
+@dataclasses.dataclass
+class LineContext:
+    number: int
+    content: str
+    is_error_line: bool
+
+
+@dataclasses.dataclass
+class CodeContext:
+    filename: str
+    error_line: int
+    context_start: int | None
+    context_end: int | None
+    lines: list[LineContext]
+
+
+@dataclasses.dataclass
+class SystemInfo:
+    platform: str
+    python_version: str
+    python_implementation: str
+    architecture: str
+    machine: str
+    processor: str
+    system: str
+    release: str
+
+
+@dataclasses.dataclass
+class StackFrame:
+    filename: str
+    line_number: int
+    function_name: str
+    code_context: CodeContext
+    locals: dict[str, Any]
+
+
+@dataclasses.dataclass
+class ExceptionData:
+    id: str
+    timestamp: str
+    exception_type: str
+    exception_module: str
+    exception_message: str
+    traceback_text: str
+    stack_frames: list[StackFrame]
+    system_info: SystemInfo
+    git_info: GitInfo | None
+
+
+def list_cached_exceptions() -> list[pathlib.Path]:
+    """List all cached exception files."""
+    if not TRACE_CACHE_DIR.exists():
+        return []
+
+    return sorted(TRACE_CACHE_DIR.glob('trace_*.json'), reverse=True)
+
+
+def save_exception_data(exception_data: ExceptionData) -> pathlib.Path:
+    """Save exception data to cache directory."""
+    # Ensure cache directory exists
+    TRACE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Create filename with timestamp and exception ID
+    timestamp = datetime.datetime.fromisoformat(exception_data.timestamp)
+    filename = (
+        f'trace_{timestamp.strftime("%Y%m%d_%H%M%S")}_{exception_data.id[:8]}.json'
+    )
+    file_path = TRACE_CACHE_DIR / filename
+
+    # Save the data
+    schema = marshmallow_dataclass.class_schema(ExceptionData)()
+    with file_path.open('w', encoding='utf-8') as f:
+        f.write(schema.dumps(exception_data))
+
+    return file_path
+
+
+def load_exception_data(file_path: pathlib.Path) -> ExceptionData:
+    """Load exception data from a cache file."""
+    return cast(
+        ExceptionData,
+        marshmallow_dataclass.class_schema(ExceptionData)().loads(
+            file_path.read_text()
+        ),
+    )

--- a/nlb/sharetrace/sharetrace.py
+++ b/nlb/sharetrace/sharetrace.py
@@ -1,0 +1,484 @@
+import datetime
+import pathlib
+import webbrowser
+
+import jinja2
+import pygments
+import rich_click as click
+from InquirerPy.prompts import confirm as confirm_prompt
+from InquirerPy.prompts import list as list_prompt
+from pygments import formatters
+from pygments import lexers
+from pygments import util
+
+from nlb.sharetrace import interface
+from nlb.util import console_utils
+
+
+def _select_exception_file() -> pathlib.Path | None:
+    """Prompt user to select an exception file from the cache."""
+    cached_files = interface.list_cached_exceptions()
+
+    if not cached_files:
+        console_utils.Console().error('No cached exception files found!')
+        return None
+
+    # Create display choices with exception info
+    choices = []
+    for file_path in cached_files:
+        try:
+            data = interface.load_exception_data(file_path)
+            timestamp = datetime.datetime.fromisoformat(data.timestamp)
+            choice_text = f'{timestamp.strftime("%Y-%m-%d %H:%M:%S")} - {data.exception_type}: {data.exception_message[:60]}{"..." if len(data.exception_message) > 60 else ""}'
+            choices.append({'name': choice_text, 'value': file_path})
+        except Exception as e:
+            choices.append(
+                {'name': f'{file_path.name} (Error loading: {e})', 'value': file_path}
+            )
+
+    selected_file = list_prompt.ListPrompt(
+        message='Select exception to visualize:',
+        choices=choices,
+    ).execute()
+
+    return selected_file
+
+
+def _get_syntax_highlighted_code(code: str, filename: str) -> str:
+    """Get syntax highlighted HTML for code."""
+    try:
+        # Try to determine lexer from filename
+        if filename.endswith('.py'):
+            lexer = lexers.get_lexer_by_name('python')
+        elif filename.endswith('.js'):
+            lexer = lexers.get_lexer_by_name('javascript')
+        elif filename.endswith('.ts'):
+            lexer = lexers.get_lexer_by_name('typescript')
+        elif filename.endswith('.html'):
+            lexer = lexers.get_lexer_by_name('html')
+        elif filename.endswith('.css'):
+            lexer = lexers.get_lexer_by_name('css')
+        elif filename.endswith('.json'):
+            lexer = lexers.get_lexer_by_name('json')
+        elif filename.endswith('.yaml') or filename.endswith('.yml'):
+            lexer = lexers.get_lexer_by_name('yaml')
+        elif filename.endswith('.md'):
+            lexer = lexers.get_lexer_by_name('markdown')
+        else:
+            lexer = lexers.get_lexer_by_name('text')
+    except util.ClassNotFound:
+        lexer = lexers.get_lexer_by_name('text')
+
+    formatter = formatters.HtmlFormatter(
+        style='github-dark',
+        linenos=True,
+        linenostart=1,
+        cssclass='highlight',
+        wrapcode=True,
+    )
+
+    return pygments.highlight(code, lexer, formatter)
+
+
+def _generate_html_report(
+    exception_data: interface.ExceptionData, output_path: pathlib.Path
+) -> None:
+    """Generate an HTML report for the exception data."""
+    # Get CSS for syntax highlighting
+    formatter = formatters.HtmlFormatter(style='github-dark', cssclass='highlight')
+    highlight_css = formatter.get_style_defs('.highlight')
+
+    # HTML template
+    template_str = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Exception Report: {{ exception_data.exception_type }}</title>
+    <style>
+        {{ highlight_css }}
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #e6e6e6;
+            background-color: #0d1117;
+            margin: 0;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .header {
+            background-color: #21262d;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            border-left: 4px solid #f85149;
+        }
+
+        .exception-title {
+            font-size: 2em;
+            margin: 0 0 10px 0;
+            color: #f85149;
+        }
+
+        .exception-message {
+            font-size: 1.2em;
+            margin: 0;
+            color: #ffa657;
+        }
+
+        .section {
+            background-color: #161b22;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            border: 1px solid #30363d;
+        }
+
+        .section-title {
+            font-size: 1.3em;
+            margin: 0 0 15px 0;
+            color: #58a6ff;
+            border-bottom: 2px solid #58a6ff;
+            padding-bottom: 5px;
+        }
+
+        .stack-frame {
+            background-color: #0d1117;
+            border: 1px solid #30363d;
+            border-radius: 6px;
+            margin-bottom: 15px;
+            overflow: hidden;
+        }
+
+        .frame-header {
+            background-color: #21262d;
+            padding: 10px 15px;
+            font-weight: bold;
+            color: #f0f6fc;
+        }
+
+        .frame-location {
+            color: #58a6ff;
+        }
+
+        .frame-function {
+            color: #79c0ff;
+        }
+
+        .code-context {
+            padding: 0;
+        }
+
+        .highlight {
+            margin: 0;
+            font-size: 0.9em;
+        }
+
+        .highlight pre {
+            margin: 0;
+            padding: 15px;
+            overflow-x: auto;
+        }
+
+        .error-line {
+            background-color: #490202 !important;
+        }
+
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+        }
+
+        .info-item {
+            background-color: #21262d;
+            padding: 15px;
+            border-radius: 6px;
+        }
+
+        .info-label {
+            font-weight: bold;
+            color: #79c0ff;
+            margin-bottom: 5px;
+        }
+
+        .info-value {
+            color: #e6e6e6;
+            word-break: break-all;
+        }
+
+        .locals-section {
+            background-color: #0d1117;
+            border: 1px solid #30363d;
+            border-radius: 6px;
+            margin-top: 10px;
+        }
+
+        .locals-header {
+            background-color: #21262d;
+            padding: 10px 15px;
+            font-weight: bold;
+            color: #f0f6fc;
+            border-bottom: 1px solid #30363d;
+        }
+
+        .locals-content {
+            padding: 15px;
+            max-height: 300px;
+            overflow-y: auto;
+        }
+
+        .local-var {
+            margin-bottom: 8px;
+        }
+
+        .var-name {
+            color: #79c0ff;
+            font-weight: bold;
+        }
+
+        .var-value {
+            color: #a5a5a5;
+            margin-left: 10px;
+        }
+
+        .traceback-text {
+            background-color: #0d1117;
+            border: 1px solid #30363d;
+            border-radius: 6px;
+            padding: 15px;
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            font-size: 0.9em;
+            white-space: pre-wrap;
+            overflow-x: auto;
+            color: #e6e6e6;
+        }
+
+        .timestamp {
+            color: #7d8590;
+            font-size: 0.9em;
+        }
+
+        .git-info {
+            background-color: #21262d;
+            padding: 10px 15px;
+            border-radius: 6px;
+            margin-top: 10px;
+            font-size: 0.9em;
+        }
+
+        .git-label {
+            color: #79c0ff;
+            font-weight: bold;
+        }
+
+        .git-value {
+            color: #e6e6e6;
+            margin-left: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1 class="exception-title">{{ exception_data.exception_type }}</h1>
+            <p class="exception-message">{{ exception_data.exception_message }}</p>
+            <p class="timestamp">Generated on {{ timestamp }} | Exception ID: {{ exception_data.id }}</p>
+        </div>
+
+        {% if exception_data.git_info %}
+        <div class="section">
+            <h2 class="section-title">Repository Information</h2>
+            <div class="info-grid">
+                {% if exception_data.git_info.repository %}
+                <div class="info-item">
+                    <div class="info-label">Repository</div>
+                    <div class="info-value">{{ exception_data.git_info.repository }}</div>
+                </div>
+                {% endif %}
+                {% if exception_data.git_info.branch %}
+                <div class="info-item">
+                    <div class="info-label">Branch</div>
+                    <div class="info-value">{{ exception_data.git_info.branch }}</div>
+                </div>
+                {% endif %}
+                {% if exception_data.git_info.commit %}
+                <div class="info-item">
+                    <div class="info-label">Commit</div>
+                    <div class="info-value">{{ exception_data.git_info.commit }}</div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="section">
+            <h2 class="section-title">Stack Trace</h2>
+            {% for frame in exception_data.stack_frames %}
+            <div class="stack-frame">
+                <div class="frame-header">
+                    <span class="frame-location">{{ frame.filename }}:{{ frame.line_number }}</span>
+                    in <span class="frame-function">{{ frame.function_name }}()</span>
+                </div>
+
+                {% if frame.code_context.lines %}
+                <div class="code-context">
+                    {% set code_lines = [] %}
+                    {% for line in frame.code_context.lines %}
+                        {% set _ = code_lines.append(line.content) %}
+                    {% endfor %}
+                    {{ get_syntax_highlighted_code(code_lines|join('\n'), frame.filename) | safe }}
+                </div>
+                {% endif %}
+
+                {% if frame.locals %}
+                <div class="locals-section">
+                    <div class="locals-header">Local Variables</div>
+                    <div class="locals-content">
+                        {% for var_name, var_value in frame.locals.items() %}
+                        <div class="local-var">
+                            <span class="var-name">{{ var_name }}:</span>
+                            <span class="var-value">{{ var_value }}</span>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </div>
+
+        <div class="section">
+            <h2 class="section-title">System Information</h2>
+            <div class="info-grid">
+                <div class="info-item">
+                    <div class="info-label">Platform</div>
+                    <div class="info-value">{{ exception_data.system_info.platform }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Python Version</div>
+                    <div class="info-value">{{ exception_data.system_info.python_version }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Python Implementation</div>
+                    <div class="info-value">{{ exception_data.system_info.python_implementation }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Architecture</div>
+                    <div class="info-value">{{ exception_data.system_info.architecture }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">Machine</div>
+                    <div class="info-value">{{ exception_data.system_info.machine }}</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">System</div>
+                    <div class="info-value">{{ exception_data.system_info.system }}</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2 class="section-title">Full Traceback</h2>
+            <div class="traceback-text">{{ exception_data.traceback_text }}</div>
+        </div>
+    </div>
+</body>
+</html>
+    """
+
+    template = jinja2.Template(template_str)
+
+    # Helper function for the template
+    def get_syntax_highlighted_code(code: str, filename: str) -> str:
+        return _get_syntax_highlighted_code(code, filename)
+
+    # Generate HTML
+    html_content = template.render(
+        exception_data=exception_data,
+        highlight_css=highlight_css,
+        timestamp=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        get_syntax_highlighted_code=get_syntax_highlighted_code,
+    )
+
+    # Write to file
+    output_path.write_text(html_content, encoding='utf-8')
+
+
+def _get_output_filename(exception_data: interface.ExceptionData) -> str:
+    """Generate a suitable output filename for the exception report."""
+    timestamp = datetime.datetime.fromisoformat(exception_data.timestamp)
+    # Clean up exception type for use in filename
+    safe_exception_type = (
+        exception_data.exception_type.replace(':', '_')
+        .replace('/', '_')
+        .replace(' ', '_')
+        .replace('<', '_')
+        .replace('>', '_')
+    )
+    return f'sharetrace_{timestamp.strftime("%Y%m%d_%H%M%S")}_{exception_data.id[:8]}_{safe_exception_type}.html'
+
+
+@click.command()
+@click.option(
+    '--open-browser',
+    is_flag=True,
+    default=False,
+    help='Open the generated report in the default browser',
+)
+def main(open_browser: bool) -> None:
+    """Generate shareable HTML reports from cached exception data."""
+    console = console_utils.Console()
+
+    # Select exception file
+    selected_file = _select_exception_file()
+    if not selected_file:
+        return
+
+    try:
+        # Load exception data
+        console.info(f'Loading exception data from {selected_file.name}...')
+        exception_data = interface.load_exception_data(selected_file)
+
+        # Get output filename
+        output_filename = _get_output_filename(exception_data)
+        output_path = interface.TRACE_OUTPUT_DIR / output_filename
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Generate report
+        console.info('Generating HTML report...')
+        _generate_html_report(exception_data, output_path)
+
+        console.success(f'Shareable HTML report generated: {output_path}')
+
+        # Open in browser if requested
+        if open_browser:
+            console.info('Opening report in browser...')
+            file_url = output_path.absolute().as_uri()
+            webbrowser.open(file_url)
+        else:
+            # Ask if user wants to open in browser
+            should_open = confirm_prompt.ConfirmPrompt(
+                message='Open the report in your browser?',
+                default=True,
+            ).execute()
+
+            if should_open:
+                file_url = output_path.absolute().as_uri()
+                console.info(f'Opening: {file_url}')
+                webbrowser.open(file_url)
+
+    except Exception as e:
+        console.error(f'Error generating report: {e}')
+        raise click.Abort()
+
+
+if __name__ == '__main__':
+    main(prog_name='sharetrace')

--- a/nlb/sharetrace/sharetrace.py
+++ b/nlb/sharetrace/sharetrace.py
@@ -23,6 +23,11 @@ def _select_exception_file() -> pathlib.Path | None:
         console_utils.Console().error('No cached exception files found!')
         return None
 
+    # Filter to the 10 most recent files
+    cached_files = sorted(cached_files, key=lambda f: f.stat().st_mtime, reverse=True)[
+        :10
+    ]
+
     # Create display choices with exception info
     choices = []
     for file_path in cached_files:

--- a/nlb/sharetrace/sharetrace_demo.py
+++ b/nlb/sharetrace/sharetrace_demo.py
@@ -1,0 +1,32 @@
+import rich_click as click
+
+from nlb.sharetrace import st
+
+
+def test_division_by_zero():
+    """Function that will cause a ZeroDivisionError."""
+    x = 10
+    y = 0
+    return x / y
+
+
+def test_nested_error():
+    """Function that calls another function that errors."""
+    test_division_by_zero()
+
+
+@click.command()
+def main():
+    """Demo script to create a sample trace file"""
+    # Install the exception hook
+    st.install_exception_hook()
+
+    print('Testing sharetrace exception capturing...')
+    print('This will cause a ZeroDivisionError to be captured.')
+
+    # This will trigger the exception hook
+    test_nested_error()
+
+
+if __name__ == '__main__':
+    main(prog_name='sharetrace_demo')

--- a/nlb/sharetrace/st.py
+++ b/nlb/sharetrace/st.py
@@ -1,0 +1,212 @@
+import datetime
+import linecache
+import pathlib
+import platform
+import subprocess
+import sys
+import traceback
+import uuid
+
+from nlb.sharetrace import interface
+
+
+def _get_git_info(file_path: str) -> interface.GitInfo | None:
+    """Get Git information for a file."""
+    try:
+        # Get the repository root
+        result = subprocess.run(
+            ['git', 'rev-parse', '--show-toplevel'],
+            cwd=pathlib.Path(file_path).parent,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+
+        repo_root = result.stdout.strip()
+
+        # Get current commit hash
+        commit_result = subprocess.run(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        commit_hash = (
+            commit_result.stdout.strip() if commit_result.returncode == 0 else None
+        )
+
+        # Get current branch
+        branch_result = subprocess.run(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        branch = branch_result.stdout.strip() if branch_result.returncode == 0 else None
+
+        # Get remote URL
+        remote_result = subprocess.run(
+            ['git', 'config', '--get', 'remote.origin.url'],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        remote_url = (
+            remote_result.stdout.strip() if remote_result.returncode == 0 else None
+        )
+
+        return interface.GitInfo(
+            repository=remote_url,
+            commit=commit_hash,
+            branch=branch,
+            root=repo_root,
+        )
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
+def _get_code_context(
+    filename: str, lineno: int, context_lines: int = 5
+) -> interface.CodeContext:
+    """Extract code context around the given line."""
+    try:
+        # Get lines around the error
+        start_line = max(1, lineno - context_lines)
+        end_line = lineno + context_lines + 1
+
+        lines: list[interface.LineContext] = []
+        for line_num in range(start_line, end_line):
+            line = linecache.getline(filename, line_num)
+            if line:  # linecache returns empty string for non-existent lines
+                lines.append(
+                    interface.LineContext(
+                        number=line_num,
+                        content=line.rstrip('\n'),
+                        is_error_line=line_num == lineno,
+                    )
+                )
+
+        return interface.CodeContext(
+            filename=filename,
+            error_line=lineno,
+            context_start=start_line,
+            context_end=end_line - 1,
+            lines=lines,
+        )
+    except Exception:
+        return interface.CodeContext(
+            filename=filename,
+            error_line=lineno,
+            context_start=None,
+            context_end=None,
+            lines=[],
+        )
+
+
+def _get_system_info() -> interface.SystemInfo:
+    """Collect system information."""
+    return interface.SystemInfo(
+        platform=platform.platform(),
+        python_version=platform.python_version(),
+        python_implementation=platform.python_implementation(),
+        architecture=platform.architecture()[0],
+        machine=platform.machine(),
+        processor=platform.processor(),
+        system=platform.system(),
+        release=platform.release(),
+    )
+
+
+def _capture_exception(
+    exc_type: type, exc_value: Exception, exc_traceback
+) -> interface.ExceptionData:
+    """Capture comprehensive exception information."""
+    # Generate unique ID for this exception
+    exception_id = str(uuid.uuid4())
+    timestamp = datetime.datetime.now().isoformat()
+
+    # Extract stack trace information
+    stack_frames: list[interface.StackFrame] = []
+    git_info = None
+    tb = exc_traceback
+    while tb is not None:
+        frame = tb.tb_frame
+        filename = frame.f_code.co_filename
+        lineno = tb.tb_lineno
+        function_name = frame.f_code.co_name
+
+        if git_info is None:
+            git_info = _get_git_info(filename)
+
+        filename_relative = (
+            filename.strip(git_info.root) if git_info and git_info.root else filename
+        )
+
+        # Get code context for this frame
+        code_context = _get_code_context(filename, lineno)
+
+        stack_frames.append(
+            interface.StackFrame(
+                filename=filename_relative,
+                line_number=lineno,
+                function_name=function_name,
+                code_context=code_context,
+                locals={k: repr(v) for k, v in frame.f_locals.items()},
+            )
+        )
+
+        tb = tb.tb_next
+
+    # Format the full traceback as text
+    traceback_text = ''.join(
+        traceback.format_exception(exc_type, exc_value, exc_traceback)
+    )
+
+    return interface.ExceptionData(
+        id=exception_id,
+        timestamp=timestamp,
+        exception_type=exc_type.__name__,
+        exception_module=exc_type.__module__,
+        exception_message=str(exc_value),
+        traceback_text=traceback_text,
+        stack_frames=stack_frames,
+        system_info=_get_system_info(),
+        git_info=git_info,
+    )
+
+
+def _custom_excepthook(exc_type: type, exc_value: Exception, exc_traceback) -> None:
+    """Custom exception hook that captures and saves exception data."""
+    # Don't capture KeyboardInterrupt or SystemExit
+    if exc_type in (KeyboardInterrupt, SystemExit):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    try:
+        # Capture exception data
+        exception_data = _capture_exception(exc_type, exc_value, exc_traceback)
+
+        # Save to cache
+        cache_file = interface.save_exception_data(exception_data)
+
+        # Print the original traceback
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+
+        # Inform user about the cached data
+        print(f'\nException data saved to: {cache_file}', file=sys.stderr)
+        print('Use sharetrace to generate a shareable report.', file=sys.stderr)
+
+    except Exception as save_error:
+        # If something goes wrong with our capturing, still show the original exception
+        print(f'Error saving exception data: {save_error}', file=sys.stderr)
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+
+
+def install_exception_hook() -> None:
+    """Install the custom exception hook to capture traceback data."""
+    sys.excepthook = _custom_excepthook

--- a/nlb/sharetrace/st.py
+++ b/nlb/sharetrace/st.py
@@ -144,7 +144,9 @@ def _capture_exception(
             git_info = _get_git_info(filename)
 
         filename_relative = (
-            filename.strip(git_info.root) if git_info and git_info.root else filename
+            filename.removeprefix(git_info.root + '/')
+            if git_info and git_info.root
+            else filename
         )
 
         # Get code context for this frame
@@ -198,9 +200,13 @@ def _custom_excepthook(exc_type: type, exc_value: Exception, exc_traceback) -> N
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
         # Inform user about the cached data
-        print(f'\nException data saved to: {cache_file}', file=sys.stderr)
-        print('Use sharetrace to generate a shareable report.', file=sys.stderr)
-
+        print(
+            f'\nException data saved to: \033[96m{cache_file}\033[0m', file=sys.stderr
+        )
+        print(
+            'Use \033[96msharetrace\033[0m to generate a shareable report.',
+            file=sys.stderr,
+        )
     except Exception as save_error:
         # If something goes wrong with our capturing, still show the original exception
         print(f'Error saving exception data: {save_error}', file=sys.stderr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # - bazel run //:requirements
 # - bazel run //:venv
 # - pip install -e .  # (Optional)
+# - `Gruntfuggly.triggertaskonsave` will run this automatically
 alembic>=1.15.1,<2
 black>=24.4.2,<25
 bleak>=0.22.3,<1
@@ -9,7 +10,9 @@ fastmcp>=2.5.2,<3
 inquirerpy>=0.3.4,<1
 ipython>=8.27.0,<9
 isort>=5.13.2,<6
+jinja2>=3.1.0,<4
 matplotlib>=3.10.0,<4
+marshmallow-dataclass>=8.7.1,<9
 numpy>=2.2.2,<3
 OpenAI[realtime]>=1.68.2,<2
 portpicker>=1.6.0,<2
@@ -21,6 +24,7 @@ PyQt6>=6.8.0,<7
 pyaudio>=0.2.14,<1
 pydub>=0.25.1,<1
 pydantic>=2.10.6,<3
+pygments>=2.16.0,<3
 pynput>=1.8.1,<2
 pyserial>=3.5,<4
 pytest>=8.3.2,<9

--- a/requirements_legacy.txt
+++ b/requirements_legacy.txt
@@ -1,0 +1,5 @@
+# Streamlined requirements for backward compatibility with Python 3.10
+jinja2>=3.1.0,<4
+marshmallow-dataclass>=8.7.1,<9
+pygments>=2.16.0,<3
+rich-click>=1.8.3,<2

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -524,6 +524,10 @@ jedi==0.19.1 \
     --hash=sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd \
     --hash=sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0
     # via ipython
+jinja2==3.1.6 \
+    --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
+    --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+    # via -r requirements.txt
 jiter==0.9.0 \
     --hash=sha256:04e8ffa3c353b1bc4134f96f167a2082494351e42888dfcf06e944f2729cbe1d \
     --hash=sha256:062b756ceb1d40b0b28f326cba26cfd575a4918415b036464a52f08632731e5a \
@@ -754,7 +758,17 @@ markupsafe==3.0.2 \
     --hash=sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79 \
     --hash=sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430 \
     --hash=sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50
-    # via mako
+    # via
+    #   jinja2
+    #   mako
+marshmallow==4.0.0 \
+    --hash=sha256:3b6e80aac299a7935cfb97ed01d1854fb90b5079430969af92118ea1b12a8d55 \
+    --hash=sha256:e7b0528337e9990fd64950f8a6b3a1baabed09ad17a0dfb844d701151f92d203
+    # via marshmallow-dataclass
+marshmallow-dataclass==8.7.1 \
+    --hash=sha256:405cbaaad9cea56b3de2f85eff32a9880e3bf849f652e7f6de7395e4b1ddc072 \
+    --hash=sha256:4fb80e1bf7b31ce1b192aa87ffadee2cedb3f6f37bb0042f8500b07e6fad59c4
+    # via -r requirements.txt
 matplotlib==3.10.0 \
     --hash=sha256:01d2b19f13aeec2e759414d3bfe19ddfb16b13a1250add08d46d5ff6f9be83c6 \
     --hash=sha256:12eaf48463b472c3c0f8dbacdbf906e573013df81a0ab82f0616ea4b11281908 \
@@ -812,7 +826,9 @@ mergedeep==1.3.4 \
 mypy-extensions==1.0.0 \
     --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
     --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-    # via black
+    # via
+    #   black
+    #   typing-inspect
 narwhals==1.26.0 \
     --hash=sha256:4af8bbdea9e45638bb9a981568a8dfa880e40eb7dcf740d19fd32aea79223c6f \
     --hash=sha256:b9d7605bf1d97a9d87783a69748c39150964e2a1ab0e5a6fef3e59e56772639e
@@ -1253,6 +1269,7 @@ pygments==2.18.0 \
     --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
     --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
     # via
+    #   -r requirements.txt
     #   ipython
     #   rich
 pymap3d==3.1.0 \
@@ -1868,6 +1885,10 @@ traitlets==5.14.3 \
     # via
     #   ipython
     #   matplotlib-inline
+typeguard==4.4.2 \
+    --hash=sha256:77a78f11f09777aeae7fa08585f33b5f4ef0e7335af40005b0c422ed398ff48c \
+    --hash=sha256:a6f1065813e32ef365bc3b3f503af8a96f9dd4e0033a02c28c4a4983de8c6c49
+    # via marshmallow-dataclass
 typer==0.16.0 \
     --hash=sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855 \
     --hash=sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b
@@ -1884,8 +1905,14 @@ typing-extensions==4.12.2 \
     #   pydantic-core
     #   rich-click
     #   sqlalchemy
+    #   typeguard
     #   typer
+    #   typing-inspect
     #   typing-inspection
+typing-inspect==0.9.0 \
+    --hash=sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f \
+    --hash=sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78
+    # via marshmallow-dataclass
 typing-inspection==0.4.1 \
     --hash=sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51 \
     --hash=sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28


### PR DESCRIPTION
Tired of being sent images of tracebacks? Does the raw text not help you figure out what happened on someone else's machine? Fear not, `sharetrace` lets you easily hook into each uncaught exception and generate a shareable, informative report on what happened.

If you trust a stranger's random ZIP file, here's a sample HTML report:
[sample.zip](https://github.com/user-attachments/files/21746146/sample.zip)

Here are some screenshots of it as well:
<img width="1022" height="161" alt="image" src="https://github.com/user-attachments/assets/a50c7658-ee7a-4617-8f67-9764cc33685b" />
<img width="1222" height="432" alt="image" src="https://github.com/user-attachments/assets/ba16485e-58c2-4bc1-8f6f-47e868d95608" />
<img width="1222" height="432" alt="image" src="https://github.com/user-attachments/assets/b012ef8c-58a3-445f-a130-31d22cd0e76b" />
<img width="1213" height="592" alt="image" src="https://github.com/user-attachments/assets/d0cdc2ea-c0e9-4837-8ba7-58c9d2976711" />

