### PR TITLE
Cache libzmq compilation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,7 @@ build:lint --aspects_parameters=fail_on_violation=true --keep_going
 test --test_output=errors
 
 # From https://github.com/google/copybara?tab=readme-ov-file#using-pre-built-copybara-in-bazel
-run --java_runtime_version=remotejdk_21
+common --java_runtime_version=remotejdk_21
 
 run:pypi --run_under="TWINE_PASSWORD=$(cat $BUILD_WORKING_DIRECTORY/services/secrets/pypi.token)"
 run:testpypi --run_under="TWINE_PASSWORD=$(cat $BUILD_WORKING_DIRECTORY/services/secrets/pypi_test.token)"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "aspect_bazel_lib", version = "2.16.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_cc", version = "0.2.12")
 bazel_dep(name = "rules_platform", version = "0.1.0")
 bazel_dep(name = "rules_shell", version = "0.4.1")
 
@@ -109,11 +109,6 @@ git_override(
 )
 
 #
-# rules_foreign_cc
-#
-bazel_dep(name = "rules_foreign_cc", version = "0.13.0")
-
-#
 # Pybind11
 #
 bazel_dep(name = "pybind11_bazel", version = "2.12.0")
@@ -121,8 +116,14 @@ bazel_dep(name = "pybind11_bazel", version = "2.12.0")
 #
 # Zmq
 #
-bazel_dep(name = "cppzmq", version = "4.10.0")
-bazel_dep(name = "libzmq", version = "4.3.5.bcr.1")
+bazel_dep(name = "cppzmq", version = "4.10.0.bcr.1")
+http_archive(
+    name = "libzmq",
+    build_file = "//bzl/deps:libzmq.BUILD",
+    sha256 = "39bea5d50a1ce7a01e23363d08e33f4b204f7da5da0b32a25ce40f6ef641eb69",
+    url = "https://github.com/RyanDraves/cache-and-release/releases/download/libzmq-v4.3.5/libzmq-linux-x86_64.tar.gz",
+    strip_prefix = "libzmq-linux-x86_64",
+)
 
 #
 # Google Test

--- a/bzl/deps/libzmq.BUILD
+++ b/bzl/deps/libzmq.BUILD
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_import")
+
+cc_import(
+    name = "libzmq",
+    hdrs = glob(["include/*.h"]),
+    static_library = "lib/libzmq.a",
+    visibility = ["//visibility:public"],
+)

--- a/tools/bazelisms.md
+++ b/tools/bazelisms.md
@@ -48,6 +48,6 @@ git_override(
     remote = "https://github.com/example/repo.git",
     patch_args = ["-p1"],
     patches = ["//bzl/deps:example.patch"],
-    commit = "deafbeef",
+    commit = "deadbeef",
 )
 ```


### PR DESCRIPTION
libzmq frequently gets evicted from the cache and takes way too long to rebuild (`rules_foreign_cc` has to setup and invoke CMake/Make/shenanigans).

Since this is only used for Linux x86_64 builds, try out something different: have a [separate repo](https://github.com/RyanDraves/cache-and-release) build the library and publish the binaries & files. This repo now just pulls those prebuilt results and links them together into the build.

Inspired by https://blog.aspect.build/never-compile-protoc-again
