### PR TITLE
Security bumps to highest version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "extends": ["config:recommended"],
   "schedule": ["before 6am on Saturday"],
   "timezone": "America/New_York",
-
+  "vulnerabilityAlerts": {
+    "vulnerabilityFixStrategy": "highest"
+  },
   "packageRules": [
     {
       "description": "Ignore own GHCR images (built from this repo)",


### PR DESCRIPTION
Renovate's spamming updates 1 at a time. Just give the latest...
